### PR TITLE
Remove code that ignores special passages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Aside from the obvious benefits of a "use your own editor" solution, Twee2 provi
 * Some special story segments (e.g. StorySubtitle) used in Twee 1 are ignored. You will be warned when this happens.
 * The Twine 2 editor might not be able to re-open stories compiled using Twee2, because Twee2 does not automatically include positional data used by the visual editor (however, you can add this manually if you like).
 
+## Build
+
+To build a local copy of the gem:
+
+	gem build twee2.gemspec
+
+To install it locally (e.g., for version number 0.5.0):
+
+	gem install twee2-0.5.0.gem
+
 ## License
 
 This code is released under the GPL, version 2. It includes code (in the storyFormats directory) by other authors, including Leon Arnott: please read their licenses before redistributing.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Designed for those who preferred the Twee approach to source management, because
 
 For installation and usage, see https://dan-q.github.io/twee2/
 
+## Fork
+
+This fork fixes an issue with special passages that you may encounter with the story formats [SugarCube](http://www.motoslave.net/sugarcube/) or [Paloma](http://mcdemarco.net/tools/scree/paloma/).
+
 ## Philosophy
 
 (Why does this exist? Where is it going?)

--- a/lib/twee2/story_file.rb
+++ b/lib/twee2/story_file.rb
@@ -75,9 +75,6 @@ module Twee2
           @passages[k][:exclude_from_output] = true
         elsif k == 'StoryIncludes'
           @passages[k][:exclude_from_output] = true # includes should already have been handled above
-        elsif %w{StorySubtitle StoryAuthor StoryMenu StorySettings}.include? k
-          puts "WARNING: ignoring passage '#{k}'"
-          @passages[k][:exclude_from_output] = true
         elsif @passages[k][:tags].include? 'stylesheet'
           story_css << "#{@passages[k][:content]}\n"
           @passages[k][:exclude_from_output] = true


### PR DESCRIPTION
Some of the special passages are used in Twine 2; e.g., StoryAuthor, StorySubtitle, and StoryMenu in SugarCube 2 for Twine 2:  http://www.motoslave.net/sugarcube/2/docs/special-names.html

Since they are harmless when not used, and desired when they are used, Twee2 should not ignore/remove them.