### PR TITLE
Do not match not indented ::@include directives

### DIFF
--- a/lib/twee2/story_file.rb
+++ b/lib/twee2/story_file.rb
@@ -33,7 +33,7 @@ module Twee2
         line = lines[i]
         if line =~ /^:: *StoryIncludes */
           in_story_includes_section = true
-        elsif line =~ /^::/
+        elsif line =~ /^::(?!@)/
           in_story_includes_section = false
         elsif in_story_includes_section && (line.strip != '')
           child_file = line.strip


### PR DESCRIPTION
When the include directive is not indented it matches a wrong regex during parsing. Fixed by adding a negative look ahead.

Fixes #31 